### PR TITLE
Update DiscordRPC to 1.2.1.24

### DIFF
--- a/pc/PresenceCommon/PresenceCommon.csproj
+++ b/pc/PresenceCommon/PresenceCommon.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DiscordRichPresence" Version="1.0.150" />
+    <PackageReference Include="DiscordRichPresence" Version="1.2.1.24" />
   </ItemGroup>
 
 </Project>

--- a/pc/VitaPresence-CLI/VitaPresence-CLI.csproj
+++ b/pc/VitaPresence-CLI/VitaPresence-CLI.csproj
@@ -9,7 +9,7 @@
     <OldToolsVersion>2.0</OldToolsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DiscordRichPresence" Version="1.0.150" />
+    <PackageReference Include="DiscordRichPresence" Version="1.2.1.24" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PresenceCommon\PresenceCommon.csproj" />

--- a/pc/VitaPresence-GUI/VitaPresence-GUI.csproj
+++ b/pc/VitaPresence-GUI/VitaPresence-GUI.csproj
@@ -40,11 +40,11 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DiscordRPC, Version=1.0.150.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DiscordRichPresence.1.0.150\lib\net35\DiscordRPC.dll</HintPath>
+    <Reference Include="DiscordRPC, Version=1.2.1.24, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DiscordRichPresence.1.2.1.24\lib\net45\DiscordRPC.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/pc/VitaPresence-GUI/packages.config
+++ b/pc/VitaPresence-GUI/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DiscordRichPresence" version="1.0.150" targetFramework="net48" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net48" />
+  <package id="DiscordRichPresence" version="1.2.1.24" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Updating the DiscordRPC package to 1.2.1.24 fixes Rich Presence not showing up on Discord. 
![Screenshot 2024-04-06 161217](https://github.com/Electry/VitaPresence/assets/89710975/e462db9b-ede2-4c9a-aa8b-a85b0b28fcad)